### PR TITLE
Base development images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,38 @@
+language: python
+
+cache: pip
+
+matrix:
+  include:
+  - python: "2.7"
+    env: HADOOP_VERSION=3.2.0 LATEST=true
+  - python: "3.6"
+    env: HADOOP_VERSION=2.9.2
+  - python: "3.6"
+    env: HADOOP_VERSION=3.2.0
+  - python: "3.7"
+    env: HADOOP_VERSION=3.2.0
+    dist: xenial
+
+sudo: required
+
+services: docker
+
+install: bash base/build.sh
+
+script:
+ - docker run --rm --name pydoop-base -d crs4/pydoop-base:${HADOOP_VERSION}-${TRAVIS_PYTHON_VERSION}
+ - "docker exec pydoop-base bash -c 'until datanode_cid; do sleep 0.1; done'"
+ - "docker exec pydoop-base bash -c '${PYTHON} -V'"
+ - docker exec pydoop-base mvn -v
+ - docker exec pydoop-base jps
+ - docker stop pydoop-base
+ - docker run --rm crs4/pydoop-docs-base:${HADOOP_VERSION}-${TRAVIS_PYTHON_VERSION} inkscape -V
+ - docker run --rm crs4/pydoop-docs-base:${HADOOP_VERSION}-${TRAVIS_PYTHON_VERSION} sphinx-build --version
+
+deploy:
+  provider: script
+  script: bash base/push.sh
+  on:
+    repo: crs4/pydoop-docker
+    branch: master

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,0 +1,29 @@
+ARG hadoop_version=3.2.0
+ARG python_version=3.6
+ARG maven_home=/opt/maven
+ARG maven_version=3.6.0
+
+FROM crs4/hadoop:${hadoop_version}-ubuntu
+ARG maven_home
+ARG maven_version
+ARG python_version
+ENV PYTHON=python${python_version}
+RUN v=$([ ${python_version%%.*} -eq 3 ] && echo 3 || echo) \
+    && apt-get -y update && apt-get -y install --no-install-recommends \
+      openjdk-8-jdk \
+      python${python_version}-dev \
+      python${v}-pip \
+      zip \
+    && apt clean && rm -rf /var/lib/apt-lists/* \
+    && ${PYTHON} -m pip install --no-cache-dir --upgrade pip \
+    && mkdir -p "${maven_home}" \
+    && wget -q -O - "ftp://ftp.mirrorservice.org/sites/ftp.apache.org/maven/maven-3/${maven_version}/binaries/apache-maven-${maven_version}-bin.tar.gz" | tar -xz --strip 1 -C "${maven_home}" \
+    && echo "export M2_HOME=\"${maven_home}\"" >> /etc/profile.d/maven.sh \
+    && echo "export M2=\"\${M2_HOME}/bin\"" >> /etc/profile.d/maven.sh \
+    && echo "export PATH=\"\${M2}:\${PATH}\"" >> /etc/profile.d/maven.sh
+ENV HADOOP_HOME=/opt/hadoop
+ENV M2_HOME="${maven_home}"
+ENV M2="${M2_HOME}/bin"
+ENV PATH="${M2}:${PATH}"
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8

--- a/base/Dockerfile.docs-base
+++ b/base/Dockerfile.docs-base
@@ -1,0 +1,12 @@
+ARG hadoop_version=3.2.0
+ARG python_version=3.6
+
+FROM crs4/pydoop-base:${hadoop_version}-${python_version}
+
+# Inkscape installs ImageMagick as a dep
+RUN apt-get -y update && apt-get -y install --no-install-recommends \
+      inkscape \
+    && apt clean && rm -rf /var/lib/apt-lists/* \
+    && ${PYTHON} -m pip install --no-cache-dir sphinx
+
+ENTRYPOINT []

--- a/base/README.md
+++ b/base/README.md
@@ -1,0 +1,6 @@
+# Base development images
+
+These images are meant to be used as base images for Pydoop development. They
+contain all prerequisites for running tests and examples, except for the
+Python dependencies. Decoupling the more stable subset into the base images
+allows for a faster development cycle.

--- a/base/build.sh
+++ b/base/build.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+[ -n "${DEBUG:-}" ] && set -x
+this="${BASH_SOURCE-$0}"
+this_dir=$(cd -P -- "$(dirname -- "${this}")" && pwd -P)
+
+pushd "${this_dir}"
+pv=${PYTHON_VERSION:-${TRAVIS_PYTHON_VERSION}}
+docker build . \
+  --build-arg hadoop_version=${HADOOP_VERSION} \
+  --build-arg python_version=${pv} \
+  -t crs4/pydoop-base:${HADOOP_VERSION}-${pv}
+docker build . \
+ -f Dockerfile.docs-base \
+ -t crs4/pydoop-docs-base:${HADOOP_VERSION}-${pv}
+popd

--- a/base/push.sh
+++ b/base/push.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+[ -n "${DEBUG:-}" ] && set -x
+
+img_list=(
+    pydoop-base
+    pydoop-docs-base
+)
+
+echo "${CI_PASS}" | docker login -u "${CI_USER}" --password-stdin
+
+pv=${PYTHON_VERSION:-${TRAVIS_PYTHON_VERSION}}
+for img in "${img_list[@]}"; do
+    docker push crs4/${img}:${HADOOP_VERSION}-${pv}
+    if [ -n "${LATEST:-}" ]; then
+	docker tag crs4/${img}:${HADOOP_VERSION}-${pv} crs4/${img}:latest
+	docker push crs4/${img}:latest
+    fi
+done


### PR DESCRIPTION
Adds base images for Pydoop development and testing purposes. This is essentially (most of) the same material [currently under pydoop/docker](https://github.com/crs4/pydoop/tree/cde6074f4d59a865d9e3ecfb56dc80969159a5cd/docker), which we have built manually up to this point.